### PR TITLE
サイドバーにスタイルを統一しつつ、課題締め切りを表示

### DIFF
--- a/src/contents/moocs.tsx
+++ b/src/contents/moocs.tsx
@@ -1,9 +1,11 @@
 import axios from "axios"
 import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from "plasmo"
 import { useEffect, useState } from "react"
+import type { Deadline } from "src/types/moocsTypes"
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://moocs.iniad.org/*"]
+  matches: ["https://moocs.iniad.org/*"],
+  all_frames: true
 }
 
 const url = `https://raw.githubusercontent.com/s1f102003425/deadpiro-json/main/data.json`
@@ -14,8 +16,6 @@ const fetchFileContent = async () => {
   return response.data
 }
 
-// Plasmoコンテンツスクリプトの設定
-
 // コンテンツを挿入する場所を指定。呼び出さずとも宣言だけで指定した場所に要素を配置できる。
 export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
   const aside = document.querySelector(".sidebar-menu.tree") as HTMLUListElement
@@ -23,33 +23,45 @@ export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
 }
 export const getShadowHostId = () => "INIAD-sharp"
 
-// PlasmoInlineコンポーネント
 const PlasmoInline = () => {
-  const [dataLoaded, setDataLoaded] = useState(false)
+  const [newData, setNewData] = useState<Deadline | null>(null)
 
   useEffect(() => {
-    if (!dataLoaded) {
-      const fetchData = async () => {
-        const data = await fetchFileContent()
-        console.log(data.cs2.deadline)
-        const aside = document.querySelector(".sidebar-menu.tree")
-        if (aside instanceof HTMLUListElement) {
-          const newLi = document.createElement("li")
-          newLi.textContent = "INIAD# CONTENTS"
-          newLi.style.textAlign = "left"
-          newLi.style.backgroundColor = "#1a2226"
-          newLi.style.padding = "10px 25px 10px 15px"
-          newLi.style.color = "#4b646f"
-          newLi.style.fontSize = "12px"
-          newLi.style.listStyleType = "none"
-          aside.appendChild(newLi)
-        }
-        setDataLoaded(true)
-      }
-
-      fetchData()
+    const fetchData = async () => {
+      const data = await fetchFileContent()
+      setNewData(data.cs2.deadline)
     }
-  }, [dataLoaded]) // dataLoadedを依存配列に追加
+    fetchData()
+  }, [])
+
+  useEffect(() => {
+    if (newData) {
+      const aside = document.querySelector(".sidebar-menu.tree")
+      if (aside instanceof HTMLUListElement) {
+        const newLi = document.createElement("li")
+        // ここからCSS指定。将来的にはインポートしていきたい
+        newLi.textContent = "INIAD# CONTENTS"
+        newLi.style.textAlign = "left"
+        newLi.style.backgroundColor = "#1a2226"
+        newLi.style.padding = "10px 25px 10px 15px"
+        newLi.style.color = "#4b646f"
+        newLi.style.fontSize = "12px"
+        newLi.style.listStyleType = "none"
+        aside.appendChild(newLi)
+
+        const deadlineElement = document.createElement("li")
+        deadlineElement.textContent = "課題締切"
+        deadlineElement.style.textAlign = "left"
+        deadlineElement.style.color = "#b8c7ce"
+        deadlineElement.style.fontSize = ""
+        deadlineElement.style.padding = "12px 5px 12px 15px"
+        aside.append(deadlineElement)
+        const deadlineInfo = document.createElement("div")
+        deadlineInfo.textContent = `締め切り: ${newData.month}/${newData.day} ${newData.hour}時`
+        deadlineElement.appendChild(deadlineInfo)
+      }
+    }
+  }, [newData])
 
   return null
 }

--- a/src/contents/moocs.tsx
+++ b/src/contents/moocs.tsx
@@ -3,6 +3,8 @@ import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from "plasmo"
 import { useEffect, useState } from "react"
 import type { Deadline } from "src/types/moocsTypes"
 
+import styles from "../contents/moocs/index.module.css"
+
 export const config: PlasmoCSConfig = {
   matches: ["https://moocs.iniad.org/*"],
   all_frames: true
@@ -39,22 +41,16 @@ const PlasmoInline = () => {
       const aside = document.querySelector(".sidebar-menu.tree")
       if (aside instanceof HTMLUListElement) {
         const newLi = document.createElement("li")
-        // ここからCSS指定。将来的にはインポートしていきたい
+        // ここからCSS指定。paddingだけCSS.moduleきかなかったので直書き。
+        newLi.className = styles.titleOfHeader
+        newLi.style.padding = " 10px 25px 10px 15px"
         newLi.textContent = "INIAD# CONTENTS"
-        newLi.style.textAlign = "left"
-        newLi.style.backgroundColor = "#1a2226"
-        newLi.style.padding = "10px 25px 10px 15px"
-        newLi.style.color = "#4b646f"
-        newLi.style.fontSize = "12px"
-        newLi.style.listStyleType = "none"
         aside.appendChild(newLi)
 
         const deadlineElement = document.createElement("li")
-        deadlineElement.textContent = "課題締切"
-        deadlineElement.style.textAlign = "left"
-        deadlineElement.style.color = "#b8c7ce"
-        deadlineElement.style.fontSize = ""
+        deadlineElement.className = styles.deadline
         deadlineElement.style.padding = "12px 5px 12px 15px"
+        deadlineElement.textContent = "課題締切"
         aside.append(deadlineElement)
         const deadlineInfo = document.createElement("div")
         deadlineInfo.textContent = `締め切り: ${newData.month}/${newData.day} ${newData.hour}時`

--- a/src/contents/moocs.tsx
+++ b/src/contents/moocs.tsx
@@ -1,45 +1,57 @@
 import axios from "axios"
-import type { PlasmoCSConfig } from "plasmo"
-import { useCallback, useEffect, useState } from "react"
-import type { Data } from "src/types/moocsTypes"
+import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from "plasmo"
+import { useEffect, useState } from "react"
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://moocs.iniad.org/*"],
-  all_frames: true
+  matches: ["https://moocs.iniad.org/*"]
 }
-const url = `https://raw.githubusercontent.com/jun-eg/deadline-json-fork/main/data.json`
 
-const FetchDeadLineData = () => {
-  const [data, setData] = useState<Data | null>(null)
+const url = `https://raw.githubusercontent.com/s1f102003425/deadpiro-json/main/data.json`
 
-  const getFiledata = useCallback(async () => {
-    try {
-      const response = await axios.get<Data>(url)
-      setData(response.data)
-    } catch (error) {
-      console.error(error)
-    }
-  }, [])
+// JSONデータを取得する非同期関数
+const fetchFileContent = async () => {
+  const response = await axios.get(url)
+  return response.data
+}
+
+// Plasmoコンテンツスクリプトの設定
+
+// コンテンツを挿入する場所を指定。呼び出さずとも宣言だけで指定した場所に要素を配置できる。
+export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
+  const aside = document.querySelector(".sidebar-menu.tree") as HTMLUListElement
+  return aside
+}
+export const getShadowHostId = () => "INIAD-sharp"
+
+// PlasmoInlineコンポーネント
+const PlasmoInline = () => {
+  const [dataLoaded, setDataLoaded] = useState(false)
 
   useEffect(() => {
-    getFiledata()
-  }, [getFiledata])
+    if (!dataLoaded) {
+      const fetchData = async () => {
+        const data = await fetchFileContent()
+        console.log(data.cs2.deadline)
+        const aside = document.querySelector(".sidebar-menu.tree")
+        if (aside instanceof HTMLUListElement) {
+          const newLi = document.createElement("li")
+          newLi.textContent = "INIAD# CONTENTS"
+          newLi.style.textAlign = "left"
+          newLi.style.backgroundColor = "#1a2226"
+          newLi.style.padding = "10px 25px 10px 15px"
+          newLi.style.color = "#4b646f"
+          newLi.style.fontSize = "12px"
+          newLi.style.listStyleType = "none"
+          aside.appendChild(newLi)
+        }
+        setDataLoaded(true)
+      }
 
-  if (!data) return <div>GettingData</div>
+      fetchData()
+    }
+  }, [dataLoaded]) // dataLoadedを依存配列に追加
 
-  return (
-    <div>
-      <p>
-        {`${data.year[2023].classes["RW2"].curses["class2"].name}, ${data.year[2023].classes["RW2"].curses["class2"].description},${data.year[2023].classes["RW2"].curses["class2"].deadline.month}/${data.year[2023].classes["RW2"].curses["class2"].deadline.day}/${data.year[2023].classes["RW2"].curses["class2"].deadline.hour}時`}
-      </p>
-      <p>
-        {`${data.year[2023].classes["cs2"].curses["class2"].name}, ${data.year[2023].classes["cs2"].curses["class2"].description},${data.year[2023].classes["cs2"].curses["class2"].deadline.month}/${data.year[2023].classes["cs2"].curses["class2"].deadline.day}/${data.year[2023].classes["cs2"].curses["class2"].deadline.hour}時`}
-      </p>
-      <p>
-        {`${data.year[2023].classes["情報連携学概論"].curses["none"].name}, ${data.year[2023].classes["情報連携学概論"].curses["none"].description},${data.year[2023].classes["情報連携学概論"].curses["none"].deadline.month}/${data.year[2023].classes["情報連携学概論"].curses["none"].deadline.day}/${data.year[2023].classes["情報連携学概論"].curses["none"].deadline.hour}時`}
-      </p>
-    </div>
-  )
+  return null
 }
 
-export default FetchDeadLineData
+export default PlasmoInline

--- a/src/contents/moocs/index.module.css
+++ b/src/contents/moocs/index.module.css
@@ -7,3 +7,12 @@ body:has(.container) {
   min-height: 100dvh;
   background-color: #fdfeff;
 }
+
+.titleOfHeader {
+  padding: 10px 25px 10px 15px;
+  font-size: "12px";
+  color: #4b646f;
+  color: "#9999";
+  text-align: right;
+  background-color: #1a2226;
+}

--- a/src/contents/moocs/index.module.css
+++ b/src/contents/moocs/index.module.css
@@ -10,9 +10,17 @@ body:has(.container) {
 
 .titleOfHeader {
   padding: 10px 25px 10px 15px;
-  font-size: "12px";
-  color: #4b646f;
-  color: "#9999";
-  text-align: right;
-  background-color: #1a2226;
+  font-size: 12px;
+  color: rgb(75 100 111);
+  text-align: left;
+  list-style-type: none;
+  background-color: rgb(26 34 38);
+}
+
+.deadline {
+  padding: 12px 5px 12px 15px;
+  font-size: 14px;
+  color: rgb(184 199 206);
+  text-align: left;
+  list-style-type: none;
 }


### PR DESCRIPTION
## 内容

ピロピロが行っていたイシューを引き継ぎサイドバーに課題締め切りを表示させるようにしました。

## 変更点

内容と同じ

## スクリーンショット・動画など

<img width="192" alt="image" src="https://github.com/INIAD-ts/INIAD-sharp/assets/131662887/1daf8390-aa2f-459d-b285-70e232c23d2f">
これはサイドバーを展開したとき
<img width="37" alt="スクリーンショット 2023-12-08 001233" src="https://github.com/INIAD-ts/INIAD-sharp/assets/131662887/9133f019-68c8-4859-92ce-01a292974630">
これはサイドバーをたたんでいいる状態


## その他
スライドを折りたたんだ状態のCSSだけ未完成です。
ひとまず基盤ができたのでピロピロがTSを駆使して引き継いでください。
分からないところは極力解説するので聞いてください